### PR TITLE
Use combined-stream2 library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,3 @@
+v0.0.4
+
+* Use combined-stream2 library for compatibility with event-stream.

--- a/index.coffee
+++ b/index.coffee
@@ -1,5 +1,5 @@
 crcUtils = require 'resin-crc-utils'
-CombinedStream = require 'combined-stream'
+CombinedStream = require 'combined-stream2'
 { DeflateCRC32Stream } = require 'crc32-stream'
 
 # Zip constants, explained how they are used on each function.

--- a/index.coffee
+++ b/index.coffee
@@ -194,7 +194,7 @@ getCombinedCrc = (parts) ->
 exports.totalLength = totalLength = (entries) ->
 	return ZIP_ECD_SIZE + entries.reduce ((sum, x) -> sum + x.zLen), 0
 
-exports.createEntry = (filename, parts, mdate) ->
+exports.createEntry = createEntry = (filename, parts, mdate) ->
 	mdate ?= new Date()
 	compressed_size = parts.reduce ((sum, x) -> sum + x.zLen), 0
 	uncompressed_size = parts.reduce ((sum, x) -> sum + x.len), 0
@@ -211,10 +211,16 @@ exports.createEntry = (filename, parts, mdate) ->
 	entry.stream.append(stream) for { stream } in parts
 	return entry
 
-exports.createZip = createZip = (entries) ->
+exports.create = create = (entries) ->
 	out = CombinedStream.create()
 	out.append(stream) for { stream } in entries
 	out.append(createCDRecord(entry)) for entry in entries
 	out.append(createEndOfCDRecord(entries))
 	out.zLen = totalLength(entries)
 	return out
+
+# DEPRECATED
+# Single-entry zip archive backwards-compatibility
+exports.createZip = (filename, parts, mdate) ->
+	entry = createEntry(filename, parts, mdate)
+	create([ entry ])

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zip-part-stream",
-  "version": "0.0.4",
+  "version": "0.0.6",
   "description": "Create zip from multiple pre-compressed partial files.",
   "scripts": {
     "test": "./node_modules/.bin/mocha --compilers coffee:coffee-script/register test/index.coffee"

--- a/package.json
+++ b/package.json
@@ -1,13 +1,13 @@
 {
   "name": "zip-part-stream",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "Create zip from multiple pre-compressed partial files.",
   "scripts": {
     "test": "./node_modules/.bin/mocha --compilers coffee:coffee-script/register test/index.coffee"
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "combined-stream": "~1.0.5",
+    "combined-stream2": "~1.1.1",
     "crc32-stream": "~0.4.0",
     "resin-crc-utils": "^1.0.1"
   },

--- a/test/index.coffee
+++ b/test/index.coffee
@@ -2,7 +2,7 @@ Promise = require 'bluebird'
 fs = Promise.promisifyAll(require 'fs')
 path = require 'path'
 { expect } = require './utils/chai'
-{ createZip, createEntry } = require '..'
+{ create, createZip, createEntry } = require '..'
 
 mdate = new Date(2016, 0, 1, 0, 0, 0) # use the same mdate in all tests
 
@@ -28,7 +28,7 @@ describe 'createZip', ->
 				part = require('./fixtures/single-entry/test.txt.json')
 				part.stream = fs.createReadStream('test/fixtures/single-entry/test.txt.deflate')
 				entry = createEntry('input.txt', [ part ], mdate)
-				stream = createZip([ entry ])
+				stream = create([ entry ])
 				expect(stream).to.be.a.Stream
 				expect(drain(stream)).to.eventually.deep.equal(fs.readFileSync('test/fixtures/single-entry/output.zip'))
 
@@ -39,7 +39,7 @@ describe 'createZip', ->
 				part2 = require('./fixtures/single-entry-parts/test2.txt.json')
 				part2.stream = fs.createReadStream('test/fixtures/single-entry-parts/test2.txt.deflate')
 				entry = createEntry('input.txt', [ part1, part2 ], mdate)
-				stream = createZip([ entry ])
+				stream = create([ entry ])
 				expect(stream).to.be.a.Stream
 				expect(drain(stream)).to.eventually.deep.equal(fs.readFileSync('test/fixtures/single-entry-parts/output.zip'))
 
@@ -55,6 +55,6 @@ describe 'createZip', ->
 			part4 = require('./fixtures/multiple-entries/hello2.txt.json')
 			part4.stream = fs.createReadStream('test/fixtures/multiple-entries/hello2.txt.deflate')
 			entry2 = createEntry('hello.txt', [ part3, part4 ], mdate)
-			stream = createZip([ entry1, entry2 ])
+			stream = create([ entry1, entry2 ])
 			expect(stream).to.be.a.Stream
 			expect(drain(stream)).to.eventually.deep.equal(fs.readFileSync('test/fixtures/multiple-entries/output.zip'))


### PR DESCRIPTION
combined-stream2 is compatible with Streams v2 API, and therefore plays
nicer with the libraries we use in our services, for example
event-stream.

This fixes an issue we have currently on image-maker, where event-stream
writes too much data to the zip library, before that is able to write it
to the response, throwing "CombinedStream#maxDataSize max data size exceeded".
