### PR TITLE
Use combined stream version 1.

### DIFF
--- a/index.coffee
+++ b/index.coffee
@@ -1,5 +1,5 @@
 crcUtils = require 'resin-crc-utils'
-CombinedStream = require 'combined-stream2'
+CombinedStream = require 'combined-stream'
 { DeflateCRC32Stream } = require 'crc32-stream'
 
 # Zip constants, explained how they are used on each function.

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "combined-stream2": "~1.1.1",
+    "combined-stream": "~1.0.5",
     "crc32-stream": "~0.4.0",
     "resin-crc-utils": "^1.0.1"
   },

--- a/test/index.coffee
+++ b/test/index.coffee
@@ -46,6 +46,7 @@ describe 'createZip', ->
 				entry = createEntry('input.txt', [ part ], mdate)
 				stream = create([ entry ])
 				expect(stream).to.be.a.Stream
+				expect(stream.zLen).to.equal(fs.readFileSync('test/fixtures/single-entry/output.zip').length)
 				drain(stream).then (data) ->
 					expect(data).to.deep.equal(fs.readFileSync('test/fixtures/single-entry/output.zip'))
 				.asCallback(done)
@@ -65,6 +66,7 @@ describe 'createZip', ->
 				entry = createEntry('input.txt', [ part1, part2 ], mdate)
 				stream = create([ entry ])
 				expect(stream).to.be.a.Stream
+				expect(stream.zLen).to.equal(fs.readFileSync('test/fixtures/single-entry-parts/output.zip').length)
 				drain(stream).then (data) ->
 					expect(data).to.deep.equal(fs.readFileSync('test/fixtures/single-entry-parts/output.zip'))
 				.asCallback(done)
@@ -91,6 +93,7 @@ describe 'createZip', ->
 			entry2 = createEntry('hello.txt', [ part3, part4 ], mdate)
 			stream = create([ entry1, entry2 ])
 			expect(stream).to.be.a.Stream
+			expect(stream.zLen).to.equal(fs.readFileSync('test/fixtures/multiple-entries/output.zip').length)
 			drain(stream).then (data) ->
 				expect(data).to.deep.equal(fs.readFileSync('test/fixtures/multiple-entries/output.zip'))
 			.asCallback(done)


### PR DESCRIPTION
We had moved to combined stream v2 when img-maker was using node streams v2, but we don't need them anymore, and for some reason combined stream does not work with the streams returned by aws sdk s3 library.
