### PR TITLE
Add id-token: write permission for NPM OIDC publishing

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -9,6 +9,11 @@ on:
     types: [opened, synchronize, closed]
     branches: [main, master]
 
+permissions:
+  id-token: write
+  contents: read
+  packages: read
+
 jobs:
   flowzone:
     name: Flowzone

--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -24,5 +24,3 @@ jobs:
       (github.event.pull_request.head.repo.full_name == github.repository && github.event_name == 'pull_request') ||
       (github.event.pull_request.head.repo.full_name != github.repository && github.event_name == 'pull_request_target')
     secrets: inherit
-    with:
-      repo_config: true

--- a/package.json
+++ b/package.json
@@ -4,6 +4,10 @@
   "description": "Create zip from multiple pre-compressed partial files.",
   "author": "Balena Ltd. <hello@balena.io>",
   "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/balena-io-modules/zip-part-stream.git"
+  },
   "scripts": {
     "prepare": "./node_modules/.bin/coffee -c index.coffee",
     "test": "./node_modules/.bin/mocha --require coffeescript/register test/index.coffee"


### PR DESCRIPTION
Add `id-token: write` permission to enable NPM publishing via OIDC trusted publishers.
Include `contents: read` and `packages: read` to preserve org default permissions.

Connects-to: https://balena.fibery.io/Work/Improvement/3782

Change-type: patch